### PR TITLE
Add IPv6 compatibility to the DNS handling

### DIFF
--- a/vpn_slice/main.py
+++ b/vpn_slice/main.py
@@ -200,7 +200,7 @@ def do_post_connect(env, args):
     for host in args.hosts:
         ips = providers.dns.lookup_host(
                 host, dns_servers=env.dns, search_domains=args.domain,
-                bind_address=env.myaddr)
+                bind_addresses=env.myaddrs)
         if ips is None:
             print("WARNING: Lookup for %s on VPN DNS servers failed." % host, file=stderr)
         else:
@@ -255,7 +255,7 @@ def do_post_connect(env, args):
             shuffle(dns)
             if args.verbose > 1:
                 print("Issuing DNS lookup of %s to prevent idle timeout..." % dummy, file=stderr)
-            providers.dns.lookup_host(dummy, dns_servers=dns, bind_address=env.myaddr)
+            providers.dns.lookup_host(dummy, dns_servers=dns, bind_addresses=env.myaddrs)
 
 ########################################
 
@@ -273,11 +273,11 @@ vpncenv = [
     ('netmask','INTERNAL_IP4_NETMASK',IPv4Address), # a.b.c.d
     ('netmasklen','INTERNAL_IP4_NETMASKLEN',int),
     ('network','INTERNAL_IP4_NETADDR',IPv4Address), # a.b.c.d
-    ('dns','INTERNAL_IP4_DNS',lambda x: [IPv4Address(x) for x in x.split()],[]),
+    ('dns','INTERNAL_IP4_DNS',lambda x: [ip_address(x) for x in x.split()],[]),
     ('nbns','INTERNAL_IP4_NBNS',lambda x: [IPv4Address(x) for x in x.split()],[]),
     ('myaddr6','INTERNAL_IP6_ADDRESS',IPv6Interface), # x:y::z or x:y::z/p
     ('netmask6','INTERNAL_IP6_NETMASK',IPv6Interface), # x:y:z:: or x:y::z/p
-    ('dns6','INTERNAL_IP6_DNS',lambda x: [IPv6Address(x) for x in x.split()],[]),
+    ('dns6','INTERNAL_IP6_DNS',lambda x: [ip_address(x) for x in x.split()],[]),
     ('nsplitinc','CISCO_SPLIT_INC',int,0),
     ('nsplitexc','CISCO_SPLIT_EXC',int,0),
     ('nsplitinc6','CISCO_IPV6_SPLIT_INC',int,0),
@@ -310,6 +310,12 @@ def parse_env(environ=os.environ):
         env.myaddr6 = env.myaddr6.ip
     else:
         env.network6 = None
+
+    env['myaddrs'] = []
+    if env.myaddr:
+        env.myaddrs.append(env.myaddr)
+    if env.myaddr6:
+        env.myaddrs.append(env.myaddr6)
 
     # Handle splits
     env.splitinc = []

--- a/vpn_slice/provider.py
+++ b/vpn_slice/provider.py
@@ -100,7 +100,7 @@ class FirewallProvider(metaclass=ABCMeta):
 
 class DNSProvider(metaclass=ABCMeta):
     @abstractmethod
-    def lookup_host(self, hostname, dns_servers, *, bind_address=None, search_domains=()):
+    def lookup_host(self, hostname, dns_servers, *, bind_addresses=None, search_domains=()):
         """Look up the address of a host."""
 
 


### PR DESCRIPTION
Hey Dan

They way I did it with dig is that now it splits the DNS requests into one call that includes all the IPv4 DNS server addresses and binds to the VPN internal IPv4 address and a second call that has all the IPv6 DNS server addresses and binds to the VPN internal IPv6 address.

All of those calls ask for both the A and the AAAA record, because I didn't really see a reason why I shouldn't ask a server I contact over its IPv4 address about the AAAA record or one that I contact over IPv6 about the A record. I figured asking doesn't hurt if we're doing a request anyway.

The command line strings it assembles now look like this for my school's VPN

```
/usr/bin/dig +short +noedns -b 5.6.7.8 @31.31.31.31 @32.32.32.32 +domain=myschool.tld www.myschool.tld A www.myschool.tld AAAA
/usr/bin/dig +short +noedns -b 2001:1:2:3:4::ab @2001:555:8888::c +domain=myschool.tld www.myschool.tld A www.myschool.tld AAAA
````
I thought it over as well as I could and I don't think that I broke anything for the case where the VPN only provides an IPv4 address to the client and informs us about IPv4 DNS server addresses, but I can't test that case since I only have my school VPN, so I'll leave that part to you, Dan.

For my school it seems to work just fine. I see IPv4 and IPv6 routes in the hostfile and if I ping and traceroute an internal host the IPv6 address gets used too.
Indeed everything keeps working even if I purposely filter out the IPv4 DNS server addresses, so that it's forced to only use dig with the IPv6 DNS server address.

Best
--Joel