### PR TITLE
Enable direct execution with python -m vpn_slice

### DIFF
--- a/vpn_slice/__main__.py
+++ b/vpn_slice/__main__.py
@@ -1,0 +1,3 @@
+from .main import main
+
+main()

--- a/vpn_slice/__main__.py
+++ b/vpn_slice/__main__.py
@@ -1,3 +1,4 @@
 from .main import main
 
-main()
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This is meant to be run as an app but the user needs to create a python script just to use it. There should be a \_\_main__.py file to allow users to run the script with `python -m vpn_slice`