### PR TITLE
Use -inet6 flag for BSD route where needed

### DIFF
--- a/vpn_slice/mac.py
+++ b/vpn_slice/mac.py
@@ -40,8 +40,11 @@ class BSDRouteProvider(RouteProvider):
     def _ifconfig(self, *args):
         return subprocess.check_output([self.ifconfig] + list(map(str, args)), universal_newlines=True)
 
+    def _family_option(self, destination):
+        return '-inet6' if destination.version == 6 else '-inet'
+
     def add_route(self, destination, *, via=None, dev=None, src=None, mtu=None):
-        args = ['add']
+        args = ['add', self._family_option(destination)]
         if mtu is not None:
             args.extend(('-mtu', str(mtu)))
         if via is not None:
@@ -53,10 +56,10 @@ class BSDRouteProvider(RouteProvider):
     replace_route = add_route
 
     def remove_route(self, destination):
-        self._route('delete', destination)
+        self._route('delete', self._family_option(destination), destination)
 
     def get_route(self, destination):
-        info = self._route('get', destination)
+        info = self._route('get', self._family_option(destination), destination)
         lines = iter(info.splitlines())
         info_d = {}
         for line in lines:


### PR DESCRIPTION
My company started providing IPv6 addresses, and I got this error on macOS:

```
route: bad address: xxxx:xxx:xxx:xxxx::xxx
Traceback (most recent call last):
  File "/usr/local/bin/vpn-slice", line 11, in <module>
    load_entry_point('vpn-slice', 'console_scripts', 'vpn-slice')()
  File "vpn-slice/vpn_slice/__main__.py", line 462, in main
    do_connect(env, args)
  File "vpn-slice/vpn_slice/__main__.py", line 171, in do_connect
    providers.route.replace_route(dest, dev=env.tundev)
  File "vpn-slice/vpn_slice/mac.py", line 51, in add_route
    self._route(*args)
  File "vpn-slice/vpn_slice/mac.py", line 38, in _route
    return subprocess.check_output([self.route, '-n'] + list(map(str, args)), universal_newlines=True)
  File "python3.7/subprocess.py", line 411, in check_output
    **kwargs).stdout
  File "python3.7/subprocess.py", line 512, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['/sbin/route', '-n', 'add', '-interface', 'xxxx:xxx:xxx:xxxx::xxx', 'utun1']' returned non-zero exit status 68.
```

This PR adds the `-inet6` flag that BSD route expects in this case.