### PR TITLE
Rename package: vpn_slice -> vpn-slice

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open(version_py, 'r') as fh:
 
 ########################################
 
-setup(name="vpn_slice",
+setup(name="vpn-slice",
       version=version_pep,
       description=("vpnc-script replacement for easy split-tunnel VPN setup"),
       long_description=open('description.rst').read(),


### PR DESCRIPTION
I hope this is all that would be needed to fix #51.
I'm not a Python developer and don't maintain packages on PyPI but comparing [the current `setup.py`](https://github.com/dlenski/vpn-slice/blob/9b1393edd64e82b5e7fae4ad2789e80137e289c6/setup.py) and [that of what-vpn]( https://github.com/dlenski/what-vpn/blob/fbadc5da8052300af489985b51b45320c1db17a5/setup.py), this looked like the difference that matters.