### PR TITLE
Handle IPv6Interface objects

### DIFF
--- a/vpn_slice/dnspython.py
+++ b/vpn_slice/dnspython.py
@@ -1,4 +1,4 @@
-from ipaddress import ip_address
+from ipaddress import ip_address, ip_interface
 from dns.resolver import Resolver, NXDOMAIN, NoAnswer
 from dns.name import root, from_text
 

--- a/vpn_slice/mac.py
+++ b/vpn_slice/mac.py
@@ -1,7 +1,7 @@
 import os
 import re
 import subprocess
-from ipaddress import ip_network
+from ipaddress import ip_network, ip_interface
 
 from .posix import PosixProcessProvider
 from .provider import RouteProvider
@@ -102,8 +102,8 @@ class BSDRouteProvider(RouteProvider):
         self._ifconfig(*args)
 
     def add_address(self, device, address):
+        address = ip_interface(address)
         if address.version == 6:
-            family = 'inet6'
+            self._ifconfig(device, 'inet6', address)
         else:
-            family = 'inet'
-        self._ifconfig(device, family, ip_network(address), address)
+            self._ifconfig(device, 'inet', address.ip, address.ip, 'netmask', '255.255.255.255')

--- a/vpn_slice/provider.py
+++ b/vpn_slice/provider.py
@@ -1,4 +1,5 @@
 from abc import ABCMeta, abstractmethod
+from ipaddress import ip_interface
 
 
 class ProcessProvider(metaclass=ABCMeta):
@@ -102,7 +103,7 @@ class DNSProvider(metaclass=ABCMeta):
     def configure(self, dns_servers, *, bind_addresses=None, search_domains=()):
         """Configure provider to use the specified DNS servers, bind addresses, and search domains."""
         self.dns_servers = dns_servers
-        self.bind_addresses = bind_addresses
+        self.bind_addresses = [ip_interface(a).ip for a in bind_addresses]
         self.search_domains = search_domains
 
     @abstractmethod


### PR DESCRIPTION
I believe this should fix #54, at least on macOS. The root cause was changing the type of `env.addr6` to be `IPv6Interface` instead of `IPv6Address` without changing all of the downstream consumers to expect both address-type (for IPv4) and interface-type (for IPv6).

dnspython doesn't work when given `source="fe80::1/128"` or so, but it doesn't give an error, either. I'm not sure why this happens, but I'm guessing something obscure to do with the `struct in6_addr` or `struct sockaddr_in6` structures at the C level.

It might be worth modifying the environment loading code so that both the IPv4 and IPv6 addresses are represented as a single `IPvxInterface` object in order to make the downstream code less confusing, but I think that's more work than we want to do to unbreak the situation.