### PR TITLE
MacOS implementation of domain specific use of vpn dns

### DIFF
--- a/vpn_slice/__main__.py
+++ b/vpn_slice/__main__.py
@@ -42,7 +42,7 @@ def get_default_providers():
             prep = CheckTunDevProvider,
         )
     elif platform.startswith('darwin'):
-        from .mac import PsProvider, BSDRouteProvider, MacDomainDNSProvider
+        from .mac import PsProvider, BSDRouteProvider, MacSplitDNSProvider
         from .posix import PosixHostsFileProvider
         from .dnspython import DNSPythonProvider
         return dict(
@@ -50,7 +50,7 @@ def get_default_providers():
             route = BSDRouteProvider,
             dns = DNSPythonProvider or DigProvider,
             hosts = PosixHostsFileProvider,
-            domain_vpn_dns = MacDomainDNSProvider,
+            domain_vpn_dns = MacSplitDNSProvider,
         )
     elif platform.startswith('freebsd'):
         from .mac import BSDRouteProvider

--- a/vpn_slice/provider.py
+++ b/vpn_slice/provider.py
@@ -144,7 +144,7 @@ class TunnelPrepProvider:
 
         """
 
-class DomainDNSProvider:
+class SplitDNSProvider:
     def configure_domain_vpn_dns(self, domains, nameservers):
         """Configure domain vpn dns.
 

--- a/vpn_slice/provider.py
+++ b/vpn_slice/provider.py
@@ -143,3 +143,18 @@ class TunnelPrepProvider:
         Base class behavior is to do nothing.
 
         """
+
+class DomainDNSProvider:
+    def configure_domain_vpn_dns(self, domains, nameservers):
+        """Configure domain vpn dns.
+
+        Base class behavior is to do nothing.
+
+        """
+
+    def deconfigure_domain_vpn_dns(self, domains, nameservers):
+        """Remove domain vpn dns.
+
+        Base class behavior is to do nothing.
+
+        """


### PR DESCRIPTION
# Why

Currently if you're using vpn-slice you can't easily give a list of domains to use the vpn dns to resolve internally. This update allows the options of ```--domains-vpn-dns=domain1.com,domain2.com``` so that those domains will resolve using the vpn dns.

# macOS specifics

* with macOS you can add the domain in /etc/resolver/{domain} to have that domain use specific nameservers (in this case the vpn dns entries)
* it cleans up the configuration on_disconnect

# Notes

* This is only implemented with macOS however the interface is there to be able to be added to other platforms
* Python is definitely not something I ever code in so feel free to let me know if there's anything that should be done differently.
* Also I suck at naming things so if the parameter name should be something else let me know

# Related Issues

#37 #15 possibly #31  and could be updated to include #68 automatically in the future

