### PR TITLE
Move help text for domains-vpn-dns

### DIFF
--- a/vpn_slice/__main__.py
+++ b/vpn_slice/__main__.py
@@ -438,6 +438,7 @@ def parse_args_and_env(args=None, environ=os.environ):
     g = p.add_argument_group('Nameserver options')
     g.add_argument('--no-ns-hosts', action='store_false', dest='ns_hosts', default=True, help='Do not add nameserver aliases to /etc/hosts (default is to name them dns0.tun0, etc.)')
     g.add_argument('--nbns', action='store_true', dest='nbns', help='Include NBNS (Windows/NetBIOS nameservers) as well as DNS nameservers')
+    g.add_argument('--domains-vpn-dns', dest='vpn_domains', default=None, help="comma seperated domains to query with vpn dns")
     g = p.add_argument_group('Debugging options')
     g.add_argument('--self-test', action='store_true', help='Stop after verifying that environment variables and providers are configured properly.')
     g.add_argument('-v','--verbose', default=0, action='count', help="Explain what %(prog)s is doing")
@@ -445,7 +446,6 @@ def parse_args_and_env(args=None, environ=os.environ):
     g.add_argument('-D','--dump', action='store_true', help='Dump environment variables passed by caller')
     g.add_argument('--no-fork', action='store_false', dest='fork', help="Don't fork and continue in background on connect")
     g.add_argument('--ppid', type=int, help='PID of calling process (normally autodetected, when using openconnect or vpnc)')
-    g.add_argument('--domains-vpn-dns', dest='vpn_domains', default=None, help="comma seperated domains to query with vpn dns")
     args = p.parse_args(args)
     env = parse_env(environ)
     return p, args, env


### PR DESCRIPTION
Minor change, moves `--domains-vpn-dns` help-text from the`Debugging options` section to `Nameserver options` section