### PR TITLE
LGTM recommendation: Except block handles 'BaseException'

### DIFF
--- a/vpn_slice/__main__.py
+++ b/vpn_slice/__main__.py
@@ -148,7 +148,7 @@ def do_disconnect(env, args):
     if args.vpn_domains is not None:
         try:
             providers.domain_vpn_dns.deconfigure_domain_vpn_dns(args.vpn_domains, env.dns)
-        except:
+        except OSError:
             print("WARNING: failed to deconfigure domains vpn dns", file=stderr)
 
 


### PR DESCRIPTION
Except block directly handles BaseException.

Right now, only `MacSplitDNSProvider` implements `deconfigure_domain_vpn_dns()`, as calls to `os.remove()` or `os.removedirs()`. Therefore, the only exception that we expect is `OSError`.

By the way, it might make sense to check that the exception has been raised for the expected reason, for example:
```python
	e.errno == errno.ENOENT
```
See:
https://stackoverflow.com/questions/10840533/most-pythonic-way-to-delete-a-file-which-may-not-exist#10840586

In the long term, because other `SplitDNSProvider` subclasses might throw different exceptions in `deconfigure_domain_vpn_dns()`, it might make sense to define a specific exception for `SplitDNSProvider`, then catch all
expected exceptions in each subclass and re-raise that standard exception. That way we can distinguish between expected exceptions we plan to catch as part of normal operation, and unexpected exceptions which are usually
the result of a programming error.