### PR TITLE
Add split DNS domain to search domain in Mac split DNS configuration.

### DIFF
--- a/vpn_slice/mac.py
+++ b/vpn_slice/mac.py
@@ -123,6 +123,7 @@ class MacSplitDNSProvider(SplitDNSProvider):
             with open(resolver_file_name, "w") as resolver_file:
                 for nameserver in nameservers:
                     resolver_file.write("nameserver {}\n".format(nameserver))
+                resolver_file.write("search {}\n".format(domain))
 
     def deconfigure_domain_vpn_dns(self, domains, nameservers):
         for domain in domains:


### PR DESCRIPTION
It serves as a backup search domain in addition to existing search domain. It is more convenient to access the domains within the VPN.

Signed-off-by: Zi Yan <zi.yan@normal.zone>