### PR TITLE
Delete split-exclude routes on disconnect

### DIFF
--- a/vpn_slice/__main__.py
+++ b/vpn_slice/__main__.py
@@ -138,6 +138,15 @@ def do_disconnect(env, args):
     except CalledProcessError:
         print("WARNING: could not delete route to VPN gateway (%s)" % env.gateway, file=stderr)
 
+    for dest in args.exc_subnets:
+        providers.route.remove_route(dest)
+
+    for dest in args.subnets:
+        providers.route.remove_route(dest)
+
+    providers.route.flush_cache()
+
+
     # remove firewall rule blocking incoming traffic
     if 'firewall' in providers and not args.incoming:
         try:

--- a/vpn_slice/__main__.py
+++ b/vpn_slice/__main__.py
@@ -138,11 +138,12 @@ def do_disconnect(env, args):
     except CalledProcessError:
         print("WARNING: could not delete route to VPN gateway (%s)" % env.gateway, file=stderr)
 
+    # delete all explicitly-created routes
     for dest in args.exc_subnets:
-        providers.route.remove_route(dest)
-
-    for dest in args.subnets:
-        providers.route.remove_route(dest)
+        try:
+            providers.route.remove_route(dest)
+        except CalledProcessError:
+            print("WARNING: could not delete excluded route (%s)" % dest, file=stderr)
 
     providers.route.flush_cache()
 


### PR DESCRIPTION
The vpnc-script
(https://gitlab.com/openconnect/vpnc-scripts/-/blob/master/vpnc-script)
shipped with openconnect deletes routes when disconnecting from the VPN.
This change does the same for vpn-slice.