### PR TITLE
Python 3.6 reached end-of-life on 2021-12-23

### DIFF
--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.5', '3.6', '3.7', '3.8', '3.x']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
https://peps.python.org/pep-0494/

Add recent Python versions 3.9 and 3.10 instead.