### PR TITLE
fix crash if /etc/resolv.conf is not a symlink

### DIFF
--- a/vpn_slice/linux.py
+++ b/vpn_slice/linux.py
@@ -142,7 +142,8 @@ class ResolveConfSplitDNSProvider(SplitDNSProvider):
 class ResolvedSplitDNSProvider(SplitDNSProvider):
     @staticmethod
     def inuse():
-        return re.match("^/run/systemd/resolve/.*", os.readlink('/etc/resolv.conf')) != None
+        return not os.path.islink('/etc/resolv.conf') or \
+               re.match("^/run/systemd/resolve/.*", os.readlink('/etc/resolv.conf')) != None
 
     def __init__(self):
         self.resolvectl = get_executable('/usr/bin/resolvectl')


### PR DESCRIPTION
add check if /etc/resolv.conf is symlink to ResolvedSplitDNSProvider.inuse() before resolving the link, this prevents `EINVAL` from os.readlink()

self test would fail with "invalid argument" error since `os.readlink` would fail with `EINVAL` if the argument is not a link
