### PR TITLE
resolve to absolute path

### DIFF
--- a/vpn_slice/linux.py
+++ b/vpn_slice/linux.py
@@ -142,7 +142,7 @@ class ResolveConfSplitDNSProvider(SplitDNSProvider):
 class ResolvedSplitDNSProvider(SplitDNSProvider):
     @staticmethod
     def inuse():
-        return re.match("^/run/systemd/resolve/.*", os.readlink('/etc/resolv.conf')) != None
+        return re.match("^/run/systemd/resolve/.*", os.path.realpath('/etc/resolv.conf')) != None
 
     def __init__(self):
         self.resolvectl = get_executable('/usr/bin/resolvectl')


### PR DESCRIPTION
In ubuntu 22.10 /etc/resolv.conf resolves to ../run/systemd/resolve/stub-resolv.conf so it does not match the regex.

So, it is better to use the absolute path.