### PR TITLE
IOError → OSError

### DIFF
--- a/vpn_slice/__main__.py
+++ b/vpn_slice/__main__.py
@@ -117,7 +117,7 @@ def do_disconnect(env, args):
     for pidfile in args.kill:
         try:
             pid = int(open(pidfile).read())
-        except (IOError, ValueError):
+        except (OSError, ValueError):
             print("WARNING: could not read pid from %s" % pidfile, file=stderr)
         else:
             try: providers.process.kill(pid)

--- a/vpn_slice/freebsd.py
+++ b/vpn_slice/freebsd.py
@@ -7,7 +7,7 @@ class ProcfsProvider(PosixProcessProvider):
     def pid2exe(self, pid):
         try:
             return os.readlink('/proc/%d/file' % pid)
-        except (OSError, IOError):
+        except OSError:
             return None
 
     def ppid_of(self, pid=None):
@@ -15,5 +15,5 @@ class ProcfsProvider(PosixProcessProvider):
             return os.getppid()
         try:
             return int(next(open('/proc/%d/status' % pid)).split()[3])
-        except (OSError, ValueError, IOError):
+        except (OSError, ValueError):
             return None

--- a/vpn_slice/linux.py
+++ b/vpn_slice/linux.py
@@ -11,7 +11,7 @@ class ProcfsProvider(PosixProcessProvider):
     def pid2exe(self, pid):
         try:
             return os.readlink('/proc/%d/exe' % pid)
-        except (OSError, IOError):
+        except OSError:
             return None
 
     def ppid_of(self, pid=None):
@@ -19,7 +19,7 @@ class ProcfsProvider(PosixProcessProvider):
             return os.getppid()
         try:
             return int(next(open('/proc/%d/stat' % pid)).split()[3])
-        except (OSError, ValueError, IOError):
+        except (OSError, ValueError):
             return None
 
 


### PR DESCRIPTION
Starting from Python 3.3, the following exceptions are aliases of OSError.

https://docs.python.org/3/library/exceptions.html#concrete-exceptions