### PR TITLE
Add '--kerberos-dc REALM' option

### DIFF
--- a/vpn_slice/provider.py
+++ b/vpn_slice/provider.py
@@ -116,6 +116,15 @@ class DNSProvider(metaclass=ABCMeta):
         any valid records.
         """
 
+    @abstractmethod
+    def lookup_srv(self, query):
+        """Query SRV records using configured servers.
+
+        The resulting hostnames will be returned in order of
+        (priority, weight), with the trailing '.' stripped from each
+        hostname. See https://en.wikipedia.org/wiki/SRV_record for the
+        interpretation of these results.
+        """
 
 class HostsProvider(metaclass=ABCMeta):
     @abstractmethod


### PR DESCRIPTION
In https://github.com/dlenski/vpn-slice/issues/135, I learned that it's possible to automatically lookup the Kerberos5 domain controller (DC) hosts for a given Kerberos5 realm, by using the DNS SRV records.

For example:

    $ REALM=realm.bigcorp.com
    $ dig +short @dns0.vpn0 @dns1.vpn0 _kerberos._tcp.$REALM SRV
    0 100 88 dc-01.realm.bigcorp.com.
    0 100 88 dc-02.realm.bigcorp.com.

This makes it quite easy to automatically lookup and route the DC hosts in vpn-slice, using most of the existing machinery for looking up user-specified hostnames:

    $ openconnect … -- script "vpn-slice --kerberos-dc realm.bigcorp.com server.bigcorp.com"
    …
    Adding /etc/hosts entries for 2 nameservers...
      192.168.1.11 = dns0.vpn0
      192.168.1.12 = dns1.vpn0
    Looking up Kerberos5 DC hosts for realm 'realm.bigcorp.com' using VPN DNS servers...
    Got 2 Kerberos5 DC hosts.
    Looking up 3 hosts using VPN DNS servers...
        server.bigcorp.com = 192.168.1.234
        dc-01.realm.bigcorp.com = 192.168.1.101
        dc-02.realm.bigcorp.com = 192.168.1.102
    Added hostnames and aliases for 3 addresses to /etc/hosts.
    Added 3 routes for named hosts.
    …

