### PR TITLE
Add dedicated nftables provider

### DIFF
--- a/vpn_slice/__main__.py
+++ b/vpn_slice/__main__.py
@@ -25,12 +25,13 @@ def get_default_providers():
         DNSPythonProvider = None
 
     if platform.startswith('linux'):
-        from .linux import CheckTunDevProvider, Iproute2Provider, IptablesProvider, ProcfsProvider
+        from .linux import CheckTunDevProvider, Iproute2Provider, IptablesProvider, NftablesProvider, ProcfsProvider
         from .posix import DigProvider, PosixHostsFileProvider
+        nft_exists = os.path.exists('/sbin/nft')
         return dict(
             process = ProcfsProvider,
             route = Iproute2Provider,
-            firewall = IptablesProvider,
+            firewall = NftablesProvider if nft_exists else IptablesProvider,
             dns = DNSPythonProvider or DigProvider,
             hosts = PosixHostsFileProvider,
             prep = CheckTunDevProvider,

--- a/vpn_slice/linux.py
+++ b/vpn_slice/linux.py
@@ -99,6 +99,25 @@ class IptablesProvider(FirewallProvider):
         self._iptables('-D', 'INPUT', '-i', device, '-m', 'state', '--state', 'RELATED,ESTABLISHED', '-j', 'ACCEPT')
 
 
+class NftablesProvider(FirewallProvider):
+    def __init__(self):
+        self.nft = get_executable('/sbin/nft')
+
+    def _nft(self, *args):
+        cl = [self.nft]
+        cl.extend(args)
+        subprocess.check_call(cl)
+
+    def configure_firewall(self, device):
+        self._nft('add', 'table', 'inet', 'vpn-slice')
+        self._nft('add', 'chain', 'inet', 'vpn-slice', 'input', '{ type filter hook input priority filter; policy accept; }')
+        self._nft('add', 'rule', 'inet', 'vpn-slice', 'input', 'iifname', device, 'ct state', '{ established, related }', 'counter', 'accept')
+        self._nft('add', 'rule', 'inet', 'vpn-slice', 'input', 'iifname', device, 'counter', 'drop')
+
+    def deconfigure_firewall(self, device):
+        self._nft('delete', 'table', 'inet', 'vpn-slice')
+
+
 class CheckTunDevProvider(TunnelPrepProvider):
     def create_tunnel(self):
         node = '/dev/net/tun'


### PR DESCRIPTION
Arch Linux finally removed the `iptables-nft` package, completing the migration away from `iptables`. Most distros have supported `nftables` for more than 5 years.

This commit adds a provider for `nftables` that replicates the existing `iptables` functionality: accept established traffic, drop all other incoming traffic. With `iptables-nft`, the `iptables` rules get translated to the following table:

```
# Warning: table ip filter is managed by iptables-nft, do not touch!
table ip filter {
        chain INPUT {
                type filter hook input priority filter; policy accept;
                iifname "tun0" xt match "conntrack" counter packets 62004 bytes 34716696 accept
                iifname "tun0" counter packets 0 bytes 0 drop
        }
}
```

Now, the dedicated `nftables` provider produces the following table:
```
table inet vpn-slice {
        chain input {
                type filter hook input priority filter; policy accept;
                iifname "tun0" ct state { established, related } counter packets 524 bytes 111788 accept
                iifname "tun0" counter packets 0 bytes 0 drop
        }
}
```

The only functional difference is that the new `inet` table family will match both IPv4 and IPv6. 

The script will try the `nftables` provider by default, and fall back to the `iptables` provider if `/sbin/nft` does not exist.